### PR TITLE
CC-313 No audio on Safari

### DIFF
--- a/src/app/components/attendees/AttendeesParticipantVideo.js
+++ b/src/app/components/attendees/AttendeesParticipantVideo.js
@@ -23,7 +23,7 @@ class AttendeesParticipantVideo extends Component {
 
   updateStream(props) {
     const { stream } = props;
-    navigator.attachMediaStream(this.video, stream);
+    navigator.attachMediaStream(this.video, new MediaStream(stream.getVideoTracks()));
   }
 
   toggleScreenShareFullScreen() {


### PR DESCRIPTION
We don't need audio tracks attached to video element