### PR TITLE
CCU-125 Add conference permissions update event handling

### DIFF
--- a/src/app/actions/ConferenceActions.js
+++ b/src/app/actions/ConferenceActions.js
@@ -289,6 +289,7 @@ export class Actions {
           );
           dispatch(ConferenceActions._conferenceJoined());
           dispatch(ControlsActions.toggleWidget());
+          dispatch(ControlsActions.setConferencePermissions(res.permissions));
           dispatch(ParticipantActions.triggerHandleOnConnect());
         }
       });
@@ -396,6 +397,7 @@ export class Actions {
                       )
                     );
                     dispatch(ControlsActions.toggleWidget());
+                    dispatch(ControlsActions.setConferencePermissions(res.permissions));
                     dispatch(ParticipantActions.triggerHandleOnConnect());
                     if (VoxeetSDK.recording.current) {
                       dispatch(ControlsActions.lockRecording());
@@ -437,6 +439,7 @@ export class Actions {
                       )
                     );
                     dispatch(ControlsActions.toggleWidget());
+                    dispatch(ControlsActions.setConferencePermissions(res.permissions));
                     dispatch(ParticipantActions.triggerHandleOnConnect());
                     if (VoxeetSDK.recording.current) {
                       dispatch(ControlsActions.lockRecording());
@@ -496,6 +499,7 @@ export class Actions {
                     );
                     dispatch(ControlsActions.toggleWidget());
                     dispatch(ControlsActions.saveConstraints(constraints));
+                    dispatch(ControlsActions.setConferencePermissions(res.permissions));
                     dispatch(ParticipantActions.triggerHandleOnConnect());
                     if (VoxeetSDK.recording.current) {
                       dispatch(ControlsActions.lockRecording());
@@ -608,6 +612,7 @@ export class Actions {
                   );
                   dispatch(ControlsActions.toggleWidget());
                   dispatch(ControlsActions.saveConstraints(constraints));
+                  dispatch(ControlsActions.setConferencePermissions(res.permissions));
                   dispatch(ParticipantActions.triggerHandleOnConnect());
                   if (VoxeetSDK.recording.current) {
                     dispatch(ControlsActions.lockRecording());

--- a/src/app/actions/ConferenceActions.js
+++ b/src/app/actions/ConferenceActions.js
@@ -1471,6 +1471,10 @@ export class Actions {
         }
       });
 
+      VoxeetSDK.conference.on("permissionsUpdated", (permissions) => {
+        dispatch(ControlsActions.setConferencePermissions(permissions));
+      });
+
       VoxeetSDK.videoPresentation.on("started", (data) => {
         dispatch(ControlsActions.forceMode("speaker"));
         if (VoxeetSDK.session.participant.id === data.ownerId) {

--- a/src/app/actions/ControlsActions.js
+++ b/src/app/actions/ControlsActions.js
@@ -35,6 +35,7 @@ export const Types = {
   TOGGLE_MAX_REMOTE_PARTICIPANTS: "TOGGLE_MAX_REMOTE_PARTICIPANTS",
   TOGGLE_REQUESTED_VIDEO: "TOGGLE_REQUESTED_VIDEO",
   SET_REQUESTED_VIDEO: "SET_REQUESTED_VIDEO",
+  SET_CONFERENCE_PERMISSIONS: "SET_CONFERENCE_PERMISSIONS"
 };
 
 export class Actions {
@@ -305,6 +306,15 @@ export class Actions {
       payload: {
         participant_id,
         state
+      }
+    };
+  }
+
+  static setConferencePermissions(conferencePermissions) {
+    return {
+      type: Types.SET_CONFERENCE_PERMISSIONS,
+      payload: {
+        conferencePermissions
       }
     };
   }

--- a/src/app/components/ConferenceRoomContainer.js
+++ b/src/app/components/ConferenceRoomContainer.js
@@ -247,7 +247,8 @@ class ConferenceRoomContainer extends Component {
       displayModes,
       displayAttendeesList,
       displayAttendeesChat,
-      displayAttendeesSettings
+      displayAttendeesSettings,
+      conferencePermissions,
     } = this.props.controlsStore;
 
     return (
@@ -337,6 +338,7 @@ class ConferenceRoomContainer extends Component {
               attendeesChat={attendeesChat}
               attendeesList={attendeesList}
               dolbyVoiceEnabled={dolbyVoiceEnabled}
+              conferencePermissions={conferencePermissions}
             />
           )}
           {isJoined && (isWidgetFullScreenOn || forceFullscreen) && (
@@ -384,6 +386,7 @@ class ConferenceRoomContainer extends Component {
               toggleAttendeesSettings={this.toggleAttendeesSettings}
               attendeesSettingsOpened={displayAttendeesSettings}
               actionsButtons={actionsButtons}
+              conferencePermissions={conferencePermissions}
             />
           )}
         </aside>
@@ -420,6 +423,7 @@ ConferenceRoomContainer.propTypes = {
   attendeesChat: PropTypes.func,
   attendeesWaiting: PropTypes.func,
   dolbyVoiceEnabled: PropTypes.bool,
+  conferencePermissions: PropTypes.object,
 };
 
 export default ConferenceRoomContainer;

--- a/src/app/components/actionsBar/ActionsButtons.js
+++ b/src/app/components/actionsBar/ActionsButtons.js
@@ -61,6 +61,7 @@ class ActionsButtons extends Component {
       isFilePresentation,
       isScreenshare,
       isDemo,
+      conferencePermissions,
     } = this.props;
     let nbParticipants = 0;
     if (participants && participants.length) {
@@ -76,6 +77,7 @@ class ActionsButtons extends Component {
             !forceFullscreen &&
             (!isWebinar || (isWebinar && isAdmin)) &&
             displayActions.indexOf("mute") > -1 &&
+            conferencePermissions.has("SEND_AUDIO") &&
             !isDemo && (
               <ToggleMicrophoneButton
                 isMuted={isMuted}
@@ -88,6 +90,7 @@ class ActionsButtons extends Component {
             !forceFullscreen &&
             (!isWebinar || (isWebinar && isAdmin)) &&
             displayActions.indexOf("video") > -1 &&
+            conferencePermissions.has("SEND_VIDEO") &&
             !isDemo && (
               <ToggleVideoButton
                 videoEnabled={videoEnabled}
@@ -102,6 +105,7 @@ class ActionsButtons extends Component {
             !forceFullscreen &&
             (!isWebinar || (isWebinar && isAdmin)) &&
             displayActions.indexOf("recording") > -1 &&
+            conferencePermissions.has("RECORD") &&
             !isDemo && (
               <ToggleRecordingButton
                 isRecording={isRecording}
@@ -115,6 +119,7 @@ class ActionsButtons extends Component {
             !forceFullscreen &&
             (!isWebinar || (isWebinar && isAdmin)) &&
             displayActions.indexOf("share") > -1 &&
+            conferencePermissions.has("SHARE_SCREEN") &&
             !isDemo &&
             shareActions.length > 0 && (
               <ToggleScreenShareButton
@@ -227,6 +232,7 @@ ActionsButtons.propTypes = {
   attendeesChatOpened: PropTypes.bool.isRequired,
   toggleAttendeesSettings: PropTypes.func.isRequired,
   attendeesSettingsOpened: PropTypes.bool.isRequired,
+  conferencePermissions: PropTypes.object.isRequired,
 };
 
 ActionsButtons.defaultProps = {

--- a/src/app/components/attendees/Attendees.js
+++ b/src/app/components/attendees/Attendees.js
@@ -129,7 +129,8 @@ class Attendees extends Component {
       isWebinar: this.props.participantStore.isWebinar,
       isAdmin: this.props.participantStore.isAdmin,
       toggleMicrophone: this.toggleMicrophone,
-      toggleForwardedVideo: this.toggleForwardedVideo
+      toggleForwardedVideo: this.toggleForwardedVideo,
+      invitePermission: this.props.conferencePermissions.has("INVITE")
     });
   }
 
@@ -161,6 +162,7 @@ class Attendees extends Component {
       conferenceId,
       isVideoPresentation,
       dolbyVoiceEnabled,
+      conferencePermissions
     } = this.props;
     const {
       participants,
@@ -177,6 +179,7 @@ class Attendees extends Component {
       currentUser,
     } = this.props.participantStore;
     const participantsConnected = participants.filter((p) => p.isConnected);
+    const kickPermission = conferencePermissions.has("KICK");
     return (
       <div
         id="conference-attendees"
@@ -269,6 +272,7 @@ class Attendees extends Component {
                 saveUserPosition={this.saveUserPosition}
                 toggleMicrophone={this.toggleMicrophone}
                 dolbyVoiceEnabled={dolbyVoiceEnabled}
+                kickPermission={kickPermission}
               />
             )}
           {mode === MODE_TILES &&
@@ -294,6 +298,7 @@ class Attendees extends Component {
                 toggleMicrophone={this.toggleMicrophone}
                 isWidgetFullScreenOn={forceFullscreen || isWidgetFullScreenOn}
                 dolbyVoiceEnabled={dolbyVoiceEnabled}
+                kickPermission={kickPermission}
               />
             )}
           {mode === MODE_SPEAKER &&
@@ -331,6 +336,7 @@ class Attendees extends Component {
                 isVideoPresentation={isVideoPresentation}
                 screenShareStream={userStreamScreenShare}
                 dolbyVoiceEnabled={dolbyVoiceEnabled}
+                kickPermission={kickPermission}
               />
             )}
           {participantsConnected.length === 0 &&
@@ -366,6 +372,7 @@ Attendees.propTypes = {
   attendeesChat: PropTypes.func,
   attendeesList: PropTypes.func,
   dolbyVoiceEnabled: PropTypes.bool,
+  conferencePermissions: PropTypes.object,
 };
 
 export default Attendees;

--- a/src/app/components/attendees/AttendeesChat.js
+++ b/src/app/components/attendees/AttendeesChat.js
@@ -87,7 +87,7 @@ class AttendeesChat extends Component {
   }
 
   render() {
-    const { participants, currentUser, attendeesChatOpened } = this.props;
+    const { participants, currentUser, attendeesChatOpened, conferencePermissions } = this.props;
     const { runningAnimation } = this.state;
     const { messages } = this.props.chatStore;
     return (
@@ -156,7 +156,8 @@ class AttendeesChat extends Component {
             }
           })}
         </ul>
-        <AttendeesChatInputContainer sendMessage={this.sendMessage} />
+        { conferencePermissions.has("SEND_MESSAGE") && (
+        <AttendeesChatInputContainer sendMessage={this.sendMessage} /> )}
       </div>
     );
   }

--- a/src/app/components/attendees/AttendeesList.js
+++ b/src/app/components/attendees/AttendeesList.js
@@ -98,7 +98,7 @@ class AttendeesList extends Component {
       if (audioq > 0 && (videoq == 0 || videoq == -1)) avquality = audioq;
       //avquality = Math.max(audioq, videoq);
     }
-    const { isWebinar, isAdmin, attendeesListOpened, toggleMicrophone, toggleForwardedVideo, dolbyVoiceEnabled } = this.props;
+    const { isWebinar, isAdmin, attendeesListOpened, toggleMicrophone, toggleForwardedVideo, dolbyVoiceEnabled, invitePermission } = this.props;
     const { filteredUsers } = this.state;
     const participantsConnected = participants.filter(
       (p) => p.isConnected && p.type == "user"
@@ -477,6 +477,7 @@ class AttendeesList extends Component {
                             </span>
                           )}
                         </span>
+                        { invitePermission && (
                         <a
                           className="invite-user"
                           onClick={() =>
@@ -484,7 +485,7 @@ class AttendeesList extends Component {
                           }
                         >
                           {strings.inviteUser}
-                        </a>
+                        </a> )}
                       </span>
                     </li>
                   );
@@ -502,6 +503,7 @@ AttendeesList.propTypes = {
   isWebinar: PropTypes.bool.isRequired,
   isAdmin: PropTypes.bool.isRequired,
   dolbyVoiceEnabled: PropTypes.bool,
+  invitePermission: PropTypes.bool
 };
 
 export default AttendeesList;

--- a/src/app/components/attendees/AttendeesParticipantBar.js
+++ b/src/app/components/attendees/AttendeesParticipantBar.js
@@ -24,6 +24,7 @@ class AttendeesParticipantBar extends Component {
       kickParticipant,
       isAdminActived /*, toggleAutomatically*/,
       dolbyVoiceEnabled,
+      kickPermission,
     } = this.props;
     const { quality } = this.props.participantStore;
     let audioq = 0,
@@ -63,7 +64,7 @@ class AttendeesParticipantBar extends Component {
                 toggleMicrophone={toggleMicrophone}
               />
             )}
-            {isAdmin && isAdminActived && !participant.isMyself && (
+            {isAdmin && isAdminActived && !participant.isMyself &&  kickPermission && (
               <AttendeesKickParticipant
                 participant={participant}
                 kickParticipant={kickParticipant}
@@ -85,6 +86,7 @@ AttendeesParticipantBar.propTypes = {
   isAdmin: PropTypes.bool,
   isAdminActived: PropTypes.bool,
   dolbyVoiceEnabled: PropTypes.bool,
+  kickPermission: PropTypes.bool
 };
 
 AttendeesParticipantBar.defaultProps = {

--- a/src/app/components/attendees/modes/Speaker.js
+++ b/src/app/components/attendees/modes/Speaker.js
@@ -47,7 +47,8 @@ class Speaker extends Component {
       forceActiveUserEnabled,
       screenShareEnabled,
       nbParticipant,
-      dolbyVoiceEnabled
+      dolbyVoiceEnabled,
+      kickPermission
     } = this.props;
     let forcedActive = "";
     if (
@@ -88,6 +89,7 @@ class Speaker extends Component {
             participant={participant}
             toggleMicrophone={toggleMicrophone}
             dolbyVoiceEnabled={dolbyVoiceEnabled}
+            kickPermission={kickPermission}
           />
         )}
         {!isWidgetFullScreenOn && !dolbyVoiceEnabled && (
@@ -125,6 +127,7 @@ Speaker.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   isAdminActived: PropTypes.bool.isRequired,
   dolbyVoiceEnabled: PropTypes.bool,
+  kickPermission: PropTypes.bool
 };
 
 export default Speaker;

--- a/src/app/components/attendees/modes/SpeakerActive.js
+++ b/src/app/components/attendees/modes/SpeakerActive.js
@@ -54,7 +54,8 @@ class SpeakerActive extends Component {
       isAdminActived,
       userStream,
       isScreenshare,
-      dolbyVoiceEnabled
+      dolbyVoiceEnabled,
+      kickPermission
     } = this.props;
     const photoUrl = participant.avatarUrl || userPlaceholder;
     return (
@@ -82,6 +83,7 @@ class SpeakerActive extends Component {
                 participant={participant}
                 toggleMicrophone={toggleMicrophone}
                 dolbyVoiceEnabled={dolbyVoiceEnabled}
+                kickPermission={kickPermission}
               />
             )}
           {filePresentationEnabled && (
@@ -144,7 +146,8 @@ SpeakerActive.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   isAdminActived: PropTypes.bool.isRequired,
   mySelf: PropTypes.bool.isRequired,
-  dolbyVoiceEnabled: PropTypes.bool
+  dolbyVoiceEnabled: PropTypes.bool,
+  kickPermission: PropTypes.bool
 };
 
 export default SpeakerActive;

--- a/src/app/components/attendees/modes/Speakers.js
+++ b/src/app/components/attendees/modes/Speakers.js
@@ -53,6 +53,7 @@ class Speakers extends Component {
       videoPresentationEnabled,
       isVideoPresentation,
       dolbyVoiceEnabled,
+      kickPermission
     } = this.props;
     const {
       activeSpeaker,
@@ -157,6 +158,7 @@ class Speakers extends Component {
                     disableForceActiveSpeaker={disableForceActiveSpeaker}
                     forceActiveSpeaker={forceActiveSpeaker}
                     dolbyVoiceEnabled={dolbyVoiceEnabled}
+                    kickPermission={kickPermission}
                   />
                 );
             })}
@@ -189,6 +191,7 @@ Speakers.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   isAdminActived: PropTypes.bool.isRequired,
   dolbyVoiceEnabled: PropTypes.bool,
+  kickPermission: PropTypes.bool
 };
 
 export default Speakers;

--- a/src/app/components/attendees/modes/Tile.js
+++ b/src/app/components/attendees/modes/Tile.js
@@ -22,7 +22,8 @@ class Tile extends Component {
       (this.props.mySelf && this.props.participant.name == null) ||
       (this.props.participant.stream && nextProps.participant.stream &&
           this.props.participant.stream.id != nextProps.participant.stream.id) ||
-      (!this.props.participant.stream && nextProps.participant.stream)
+      (!this.props.participant.stream && nextProps.participant.stream) ||
+      (this.props.kickPermission != nextProps.kickPermission)
     ) {
       return true;
     }
@@ -39,7 +40,8 @@ class Tile extends Component {
       isAdminActived,
       nbParticipant,
       mySelf,
-      dolbyVoiceEnabled
+      dolbyVoiceEnabled,
+      kickPermission
     } = this.props;
     return (
       <div
@@ -69,6 +71,7 @@ class Tile extends Component {
           toggleMicrophone={toggleMicrophone}
           isWidgetFullScreenOn={isWidgetFullScreenOn}
           dolbyVoiceEnabled={dolbyVoiceEnabled}
+          kickPermission={kickPermission}
         />
         <TileLegend
           participant={participant}
@@ -96,6 +99,7 @@ Tile.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   nbParticipant: PropTypes.number,
   dolbyVoiceEnabled: PropTypes.bool,
+  kickPermission: PropTypes.bool
 };
 
 export default Tile;

--- a/src/app/components/attendees/modes/TileVideo.js
+++ b/src/app/components/attendees/modes/TileVideo.js
@@ -22,7 +22,8 @@ class TileVideo extends Component {
       isAdminActived,
       mySelf,
       isBackCamera,
-      dolbyVoiceEnabled
+      dolbyVoiceEnabled,
+      kickPermission
     } = this.props;
     const photoUrl = participant.avatarUrl || userPlaceholder;
     return (
@@ -49,6 +50,7 @@ class TileVideo extends Component {
             participant={participant}
             toggleMicrophone={toggleMicrophone}
             dolbyVoiceEnabled={dolbyVoiceEnabled}
+            kickPermission={kickPermission}
           />
         )}
       </span>
@@ -71,6 +73,7 @@ TileVideo.propTypes = {
   isAdminActived: PropTypes.bool.isRequired,
   dolbyVoiceEnabled: PropTypes.bool,
   isBackCamera: PropTypes.bool,
+  kickPermission: PropTypes.bool
 };
 
 export default TileVideo;

--- a/src/app/components/attendees/modes/Tiles.js
+++ b/src/app/components/attendees/modes/Tiles.js
@@ -21,6 +21,7 @@ class Tiles extends Component {
       currentUser,
       isWebinar,
       dolbyVoiceEnabled,
+      kickPermission
     } = this.props;
     let tilesParticipants = participants.filter(
         (p) => p.isConnected && p.type == "user"
@@ -81,6 +82,7 @@ class Tiles extends Component {
                 toggleMicrophone={toggleMicrophone}
                 isWidgetFullScreenOn={isWidgetFullScreenOn}
                 dolbyVoiceEnabled={dolbyVoiceEnabled}
+                kickPermission={kickPermission}
               />
             );
           })}
@@ -100,6 +102,7 @@ Tiles.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   isAdminActived: PropTypes.bool.isRequired,
   dolbyVoiceEnabled: PropTypes.bool,
+  kickPermission: PropTypes.bool,
 };
 
 export default Tiles;

--- a/src/app/reducers/ControlsReducer.js
+++ b/src/app/reducers/ControlsReducer.js
@@ -33,6 +33,20 @@ const defaultState = {
     "chat",
     "pstn"
   ],
+  conferencePermissions: new Set([
+    "INVITE",
+    "UPDATE_PERMISSIONS",
+    "KICK",
+    "JOIN",
+    "SEND_AUDIO",
+    "SEND_VIDEO",
+    "SHARE_SCREEN",
+    "SHARE_VIDEO",
+    "SHARE_FILE",
+    "SEND_MESSAGE",
+    "RECORD",
+    "STREAM"
+  ]),
   shareActions: ["screenshare", "filepresentation", "videopresentation"],
   displayModes: ["tiles", "speaker", "list"],
   mode: "tiles",
@@ -324,6 +338,12 @@ const ControlsReducer = (state = defaultState, action) => {
       return {
         ...state,
         requestedVideos: rv
+      };
+    }
+    case Types.SET_CONFERENCE_PERMISSIONS: {
+      return {
+        ...state,
+        conferencePermissions: action.payload.conferencePermissions
       };
     }
     default:


### PR DESCRIPTION
- Closes CCU-125

Added following behaviour to the UXKit:
- Mute/unmute button is not visible if no permission to send audio
- Camera on/off button is not visible if no permission to send video
- Screen share button is not visible if no permission to share screen
- Record button is not visible if no permission for recording
- Invite participant button is not visible if no permission to invite
- Kick participant button is not visible if no permission for kicking 
- Text input in chat is not visible if no permission to send message (reading messages is still possible)