### PR TITLE
Fix for broken 3.1.0 release -- crashes after starting a conference

### DIFF
--- a/src/app/components/ConferenceRoomContainer.js
+++ b/src/app/components/ConferenceRoomContainer.js
@@ -311,6 +311,7 @@ class ConferenceRoomContainer extends Component {
               toggleModal={this.toggleModal}
               toggleMode={this.toggleMode}
               actionsButtons={actionsButtons}
+              conferencePermissions={conferencePermissions}
             />
           )}
 


### PR DESCRIPTION
The example listed [here](https://dolby.io/developers/interactivity-apis/reference/client-ux-kit/uxkit-voxeet-react) crashes when you click the Join Room button as of the 3.1.0 release. `ConferenceRoomContainer` is not passing in the `conferencePermissions` prop like it is to the other components it renders. This fixes that.
