### PR TITLE
CCU-194: Per-client mutes for Dolby Voice Server

### DIFF
--- a/src/app/actions/ConferenceActions.js
+++ b/src/app/actions/ConferenceActions.js
@@ -290,23 +290,19 @@ export class Actions {
         voxeet: { participants },
       } = getState();
       return VoxeetSDK.createDemoConference().then(function (res) {
-        if (VoxeetSDK.extensions.hasElectron()) {
-          dispatch(ConferenceActions.hasElectron());
-        } else {
-          dispatch(
+        dispatch(
             ParticipantActions.saveCurrentUser(
-              "Me",
-              "https://gravatar.com/avatar/" +
+                "Me",
+                "https://gravatar.com/avatar/" +
                 Math.floor(Math.random() * 1000000) +
                 "?s=200&d=identicon",
-              "123456"
+                "123456"
             )
-          );
-          dispatch(ConferenceActions._conferenceJoined());
-          dispatch(ControlsActions.toggleWidget());
-          dispatch(ControlsActions.setConferencePermissions(res.permissions));
-          dispatch(ParticipantActions.triggerHandleOnConnect());
-        }
+        );
+        dispatch(ConferenceActions._conferenceJoined());
+        dispatch(ControlsActions.toggleWidget());
+        dispatch(ControlsActions.setConferencePermissions(res.permissions));
+        dispatch(ParticipantActions.triggerHandleOnConnect());
       });
     };
   }
@@ -609,82 +605,78 @@ export class Actions {
                 maxVideoForwarding: maxVideoForwarding,
               })
               .then((res) => {
-                if (VoxeetSDK.extensions.hasElectron()) {
-                  dispatch(ConferenceActions.hasElectron());
-                } else {
-                  dispatch(
+                dispatch(
                     ParticipantActions.saveCurrentUser(
-                      userInfo.name,
-                      userInfo.avatarUrl,
-                      userInfo.externalId
+                        userInfo.name,
+                        userInfo.avatarUrl,
+                        userInfo.externalId
                     )
-                  );
-                  dispatch(
+                );
+                dispatch(
                     ConferenceActions._conferenceJoined(
-                      res.id,
-                      pinCode,
-                      res.params.dolbyVoice
+                        res.id,
+                        pinCode,
+                        res.params.dolbyVoice
                     )
-                  );
-                  dispatch(ControlsActions.toggleWidget());
-                  dispatch(ControlsActions.saveConstraints(constraints));
-                  dispatch(ControlsActions.setConferencePermissions(res.permissions));
-                  dispatch(ParticipantActions.triggerHandleOnConnect());
-                  if (VoxeetSDK.recording.current) {
-                    dispatch(ControlsActions.lockRecording());
-                    dispatch(
+                );
+                dispatch(ControlsActions.toggleWidget());
+                dispatch(ControlsActions.saveConstraints(constraints));
+                dispatch(ControlsActions.setConferencePermissions(res.permissions));
+                dispatch(ParticipantActions.triggerHandleOnConnect());
+                if (VoxeetSDK.recording.current) {
+                  dispatch(ControlsActions.lockRecording());
+                  dispatch(
                       OnBoardingMessageActions.onBoardingDisplay(
-                        strings.recordConferenceStart,
-                        2000
+                          strings.recordConferenceStart,
+                          2000
                       )
-                    );
-                  } else if (autoRecording) {
-                    dispatch(ConferenceActions.toggleRecording(res.id, false));
-                    dispatch(
+                  );
+                } else if (autoRecording) {
+                  dispatch(ConferenceActions.toggleRecording(res.id, false));
+                  dispatch(
                       ConferenceActions.sendBroadcastMessage(
-                        RECORDING_STATE,
-                        null,
-                        {
-                          name: userInfo.name,
-                          userId: userInfo.participant_id,
-                          recordingRunning: true,
-                        }
+                          RECORDING_STATE,
+                          null,
+                          {
+                            name: userInfo.name,
+                            userId: userInfo.participant_id,
+                            recordingRunning: true,
+                          }
                       )
-                    );
-                  }
-                  if (constraints.video) {
-                    dispatch(ControlsActions.toggleVideo(true));
-                  }
-                  if (!constraints.audio)
-                    dispatch(ControlsActions.toggleAudio(false));
-                  if (bowser.chrome) {
-                    if (preConfigPayload != null) {
-                      if (preConfigPayload.outputDeviceSelected)
-                        VoxeetSDK.mediaDevice
+                  );
+                }
+                if (constraints.video) {
+                  dispatch(ControlsActions.toggleVideo(true));
+                }
+                if (!constraints.audio)
+                  dispatch(ControlsActions.toggleAudio(false));
+                if (bowser.chrome) {
+                  if (preConfigPayload != null) {
+                    if (preConfigPayload.outputDeviceSelected)
+                      VoxeetSDK.mediaDevice
                           .selectAudioOutput(
-                            preConfigPayload.outputDeviceSelected
+                              preConfigPayload.outputDeviceSelected
                           )
                           .catch((err) => {
                             console.log(err);
                           });
-                    } else {
-                      this.setOutputAudio(dispatch);
-                    }
+                  } else {
+                    this.setOutputAudio(dispatch);
                   }
-                  if (
+                }
+                if (
                     preConfigPayload &&
                     preConfigPayload.audioTransparentMode !== undefined
-                  ) {
-                    dispatch(
+                ) {
+                  dispatch(
                       ConferenceActions.setAudioTransparentMode(preConfigPayload.audioTransparentMode)
-                    );
-                  }
-                  if (maxVideoForwarding!==undefined
-                  ) {
-                    dispatch(
+                  );
+                }
+                if (maxVideoForwarding!==undefined
+                ) {
+                  dispatch(
                       ControlsActions.setMaxVideoForwarding(maxVideoForwarding)
-                    );
-                  }
+                  );
                 }
               })
               .catch((err) => {

--- a/src/app/actions/ConferenceActions.js
+++ b/src/app/actions/ConferenceActions.js
@@ -759,9 +759,10 @@ export class Actions {
       const {
         voxeet: { controls },
       } = getState();
-      let user = VoxeetSDK.session.participant;
+      let user;
       if (!userId) {
-        userId = VoxeetSDK.session.participant.id;
+        user = VoxeetSDK.session.participant;
+        userId = user.id;
         isMuted = controls.isMuted;
       } else {
         user = VoxeetSDK.conference.participants.get(userId);
@@ -801,7 +802,17 @@ export class Actions {
             });
         }
       } else {
-        VoxeetSDK.conference.mute(user, isMuted ? false : true);
+        if (userId === VoxeetSDK.session.participant.id) {
+          VoxeetSDK.conference.mute(user, !isMuted);
+        } else {
+          let promise;
+          if (isMuted) {
+            promise = VoxeetSDK.conference.startAudio(user);
+          } else {
+            promise = VoxeetSDK.conference.stopAudio(user);
+          }
+          return promise.then(() => dispatch(ParticipantActions.onToogleMicrophone(userId)));
+        }
       }
 
       if (userId === VoxeetSDK.session.participant.id) {

--- a/src/app/components/ConferencePreConfigContainer.js
+++ b/src/app/components/ConferencePreConfigContainer.js
@@ -78,6 +78,10 @@ class ConferencePreConfigContainer extends Component {
     this.releaseStream();
   }
 
+  reportError(error) {
+    console.error(error);
+  }
+
   onDeviceChange() {
     this.releaseStream();
 
@@ -141,6 +145,7 @@ class ConferencePreConfigContainer extends Component {
         }
       })
       .catch(error => {
+        this.reportError(error.message);
         this.setState({ videoEnabled: false });
       });
   }
@@ -235,22 +240,38 @@ class ConferencePreConfigContainer extends Component {
         })
         .then(() => {
           if (resultAudio.length > 0) {
-            navigator.mediaDevices
-              .getUserMedia({
-                audio: true,
-                video:
-                  this.state.videoEnabled && resultVideo.length > 0
-                    ? true
-                    : false
-              })
+            Promise.resolve()
+                .then(() =>{
+                  return navigator.mediaDevices
+                      .getUserMedia({
+                        audio: true,
+                        video: this.state.videoEnabled && resultVideo.length > 0
+                      }).catch((error) => {
+                        console.warn('Could not get audio or video', error && error.message)
+                        // Try audio only
+                        return  navigator.mediaDevices
+                            .getUserMedia({
+                              audio: true,
+                              video: false
+                            }).then((stream) => {
+                              // Disable video
+                              this.setState({
+                                videoEnabled: false,
+                                error: strings.errorPermissionDeniedMicrophoneCamera,
+                                loading: false
+                              });
+                              return stream;
+                            });
+                      });
+                })
               .then(stream => {
+                stream.getTracks().forEach(track => {
+                  track.stop();
+                });
                 resultAudio = new Array();
                 resultVideo = new Array();
                 resultAudioOutput = new Array();
                 navigator.mediaDevices.enumerateDevices().then(sources => {
-                  stream.getTracks().forEach(track => {
-                    track.stop();
-                  });
                   let videoCookieExist = false;
                   let outputCookieExist = false;
                   let inputCookieExist = false;
@@ -360,6 +381,7 @@ class ConferencePreConfigContainer extends Component {
                       });
                     }
                   } else {
+                    this.reportError(strings.noAudioDevice);
                     this.setState({
                       error: strings.noAudioDevice,
                       loading: false
@@ -387,17 +409,20 @@ class ConferencePreConfigContainer extends Component {
                         this.forceUpdate();
                       });
                   } else {
+                    this.reportError("No input device detected");
                     console.error("No input device detected");
                   }
                 });
               })
               .catch(error => {
                 if (this.state.videoEnabled) {
+                  this.reportError(strings.errorPermissionDeniedMicrophoneCamera);
                   this.setState({
                     error: strings.errorPermissionDeniedMicrophoneCamera,
                     loading: false
                   });
                 } else {
+                  this.reportError(strings.errorPermissionDeniedMicrophone);
                   this.setState({
                     error: strings.errorPermissionDeniedMicrophone,
                     loading: false
@@ -405,6 +430,7 @@ class ConferencePreConfigContainer extends Component {
                 }
               });
           } else {
+            this.reportError(strings.noAudioDevice);
             this.setState({ error: strings.noAudioDevice, loading: false });
           }
         });
@@ -414,7 +440,7 @@ class ConferencePreConfigContainer extends Component {
   attachSinkId(sinkId) {
     const element = document.getElementById("outputTester");
     element.setSinkId(sinkId).catch(error => {
-      console.error(errorMessage);
+      this.reportError(err.message);
     });
   }
 
@@ -466,6 +492,7 @@ class ConferencePreConfigContainer extends Component {
             return true;
           })
           .catch((err) => {
+            this.reportError(err.message);
             return false;
           });
       }
@@ -736,6 +763,7 @@ class ConferencePreConfigContainer extends Component {
                                 }
                               </div>
                               <div className="voxeet-loading-info-container">{error}</div>
+                              <div className="voxeet-loading-info-container"><button className={'retry-devices'} onClick={this.onDeviceChange}>Retry</button></div>
                             </div>
                           </div>
                         )}

--- a/src/app/components/attendees/AttendeesList.js
+++ b/src/app/components/attendees/AttendeesList.js
@@ -328,7 +328,7 @@ class AttendeesList extends Component {
                             <span className="participant-username">
                               {participant.name}
                             </span>
-                            {toggleMicrophone != null && !participant.isMyself && !dolbyVoiceEnabled && (
+                            {toggleMicrophone != null && !participant.isMyself && !(dolbyVoiceEnabled && currentUser.isListener) && (
                               <AttendeesParticipantMute
                                 participant={participant}
                                 toggleMicrophone={toggleMicrophone}

--- a/src/app/components/attendees/AttendeesParticipantBar.js
+++ b/src/app/components/attendees/AttendeesParticipantBar.js
@@ -26,7 +26,7 @@ class AttendeesParticipantBar extends Component {
       dolbyVoiceEnabled,
       kickPermission,
     } = this.props;
-    const { quality } = this.props.participantStore;
+    const { quality, currentUser } = this.props.participantStore;
     let audioq = 0,
       videoq = 0,
       avquality = 0;
@@ -58,7 +58,7 @@ class AttendeesParticipantBar extends Component {
         <div className="name">{participant.name}</div>
         <ul className="bar-icons">
           <li>
-            {toggleMicrophone != null && !participant.isMyself && !dolbyVoiceEnabled && (
+            {toggleMicrophone != null && !participant.isMyself && !(dolbyVoiceEnabled && currentUser.isListener) && (
               <AttendeesParticipantMute
                 participant={participant}
                 toggleMicrophone={toggleMicrophone}

--- a/src/app/components/attendees/AttendeesSettings.js
+++ b/src/app/components/attendees/AttendeesSettings.js
@@ -231,7 +231,7 @@ class AttendeesSettings extends Component {
     VoxeetSDK.mediaDevice.selectAudioInput(deviceId).then(() => {
       Cookies.set("input", deviceId, default_cookies_param);
       if (this.props.microphoneMuted) {
-        VoxeetSDK.conference.toggleMute(VoxeetSDK.session.participant);
+        VoxeetSDK.conference.mute(VoxeetSDK.session.participant, true);
       }
       this.props.dispatch(InputManagerActions.inputAudioChange(deviceId));
     });

--- a/src/app/components/attendees/modes/List.js
+++ b/src/app/components/attendees/modes/List.js
@@ -15,6 +15,7 @@ class List extends Component {
       kickParticipant,
       isAdmin,
       isAdminActived,
+      currentUser  // TODO no usages found for this component
     } = this.props;
     return (
       <div className="SidebarList">
@@ -29,6 +30,7 @@ class List extends Component {
                   key={i}
                   kickParticipant={kickParticipant}
                   toggleMicrophone={toggleMicrophone}
+                  currentUser={currentUser}
                 />
               );
           })}

--- a/src/app/components/attendees/modes/ListItem.js
+++ b/src/app/components/attendees/modes/ListItem.js
@@ -46,7 +46,8 @@ class ListItem extends Component {
       toggleMicrophone,
       kickParticipant,
       isAdminActived,
-      dolbyVoiceEnabled
+      dolbyVoiceEnabled,
+      currentUser
     } = this.props;
     return (
       <li
@@ -71,7 +72,7 @@ class ListItem extends Component {
           )}
           <span className="participant-username">{participant.name}</span>
         </span>
-        {!dolbyVoiceEnabled && <AttendeesParticipantMute
+        {!(dolbyVoiceEnabled && currentUser.isListener) && <AttendeesParticipantMute
           participant={participant}
           toggleMicrophone={toggleMicrophone}
         />}

--- a/src/app/components/attendees/modes/ListWidget.js
+++ b/src/app/components/attendees/modes/ListWidget.js
@@ -30,6 +30,7 @@ class ListWidget extends Component {
               isAdmin={isAdmin}
               mySelf={true}
               dolbyVoiceEnabled={dolbyVoiceEnabled}
+              currentUser={currentUser}
             />
           )}
           {participants.map((participant, i) => {
@@ -44,6 +45,7 @@ class ListWidget extends Component {
                   kickParticipant={kickParticipant}
                   toggleMicrophone={toggleMicrophone}
                   dolbyVoiceEnabled={dolbyVoiceEnabled}
+                  currentUser={currentUser}
                 />
               );
           })}

--- a/src/app/components/attendees/modes/ListWidgetItem.js
+++ b/src/app/components/attendees/modes/ListWidgetItem.js
@@ -47,7 +47,8 @@ class ListWidgetItem extends Component {
       kickParticipant,
       isAdminActived,
       mySelf,
-      dolbyVoiceEnabled
+      dolbyVoiceEnabled,
+      currentUser
     } = this.props;
     return (
       <li
@@ -72,7 +73,7 @@ class ListWidgetItem extends Component {
           )}
           <span className="participant-username">{participant.name}</span>
         </span>
-        {!mySelf && !dolbyVoiceEnabled && (
+        {!mySelf && !(dolbyVoiceEnabled && currentUser.isListener) && (
           <AttendeesParticipantMute
             participant={participant}
             toggleMicrophone={toggleMicrophone}

--- a/src/app/components/attendees/modes/OwnTile.js
+++ b/src/app/components/attendees/modes/OwnTile.js
@@ -42,7 +42,8 @@ class OwnTile extends Component {
       kickParticipant,
       isAdminActived,
       mySelf,
-      dolbyVoiceEnabled
+      dolbyVoiceEnabled,
+      currentUser
     } = this.props;
     const { currentVideoDevice, isBackCamera } = this.props.inputManager;
     return (
@@ -81,6 +82,7 @@ class OwnTile extends Component {
             isAdmin={isAdmin}
             toggleMicrophone={toggleMicrophone}
             dolbyVoiceEnabled={dolbyVoiceEnabled}
+            currentUser={currentUser}
           />
         </div>
       </Draggable>

--- a/src/app/components/attendees/modes/Speaker.js
+++ b/src/app/components/attendees/modes/Speaker.js
@@ -48,7 +48,8 @@ class Speaker extends Component {
       screenShareEnabled,
       nbParticipant,
       dolbyVoiceEnabled,
-      kickPermission
+      kickPermission,
+      currentUser
     } = this.props;
     let forcedActive = "";
     if (
@@ -92,7 +93,7 @@ class Speaker extends Component {
             kickPermission={kickPermission}
           />
         )}
-        {!isWidgetFullScreenOn && !dolbyVoiceEnabled && (
+        {!isWidgetFullScreenOn && !(dolbyVoiceEnabled && currentUser.isListener) && (
           <AttendeesParticipantMute
             participant={participant}
             toggleMicrophone={toggleMicrophone}

--- a/src/app/components/attendees/modes/Speakers.js
+++ b/src/app/components/attendees/modes/Speakers.js
@@ -159,6 +159,7 @@ class Speakers extends Component {
                     forceActiveSpeaker={forceActiveSpeaker}
                     dolbyVoiceEnabled={dolbyVoiceEnabled}
                     kickPermission={kickPermission}
+                    currentUser={currentUser}
                   />
                 );
             })}

--- a/src/app/components/attendees/modes/Tile.js
+++ b/src/app/components/attendees/modes/Tile.js
@@ -41,7 +41,8 @@ class Tile extends Component {
       nbParticipant,
       mySelf,
       dolbyVoiceEnabled,
-      kickPermission
+      kickPermission,
+      currentUser
     } = this.props;
     return (
       <div
@@ -80,6 +81,7 @@ class Tile extends Component {
           isAdmin={isAdmin}
           toggleMicrophone={toggleMicrophone}
           dolbyVoiceEnabled={dolbyVoiceEnabled}
+          currentUser={currentUser}
         />
       </div>
     );

--- a/src/app/components/attendees/modes/TileLegend.js
+++ b/src/app/components/attendees/modes/TileLegend.js
@@ -16,12 +16,13 @@ class TileLegend extends Component {
       isAdmin,
       kickParticipant,
       isAdminActived,
-      dolbyVoiceEnabled
+      dolbyVoiceEnabled,
+      currentUser
     } = this.props;
     return (
       <span className="tile-legend">
         <span className="participant-username">{participant.name}</span>
-        {!dolbyVoiceEnabled && <AttendeesParticipantMute
+        {!(dolbyVoiceEnabled && currentUser.isListener) && <AttendeesParticipantMute
           participant={participant}
           toggleMicrophone={toggleMicrophone}
         />}

--- a/src/app/components/attendees/modes/Tiles.js
+++ b/src/app/components/attendees/modes/Tiles.js
@@ -66,6 +66,7 @@ class Tiles extends Component {
               dolbyVoiceEnabled={dolbyVoiceEnabled}
               bounds={this.draggableAreaRef.current}
               key={currentUser.participant_id}
+              currentUser={currentUser}
             />
           )}
           {tilesParticipants.map((participant, i) => {
@@ -83,6 +84,7 @@ class Tiles extends Component {
                 isWidgetFullScreenOn={isWidgetFullScreenOn}
                 dolbyVoiceEnabled={dolbyVoiceEnabled}
                 kickPermission={kickPermission}
+                currentUser={currentUser}
               />
             );
           })}

--- a/src/styles/components/ConferenceLoading.less
+++ b/src/styles/components/ConferenceLoading.less
@@ -36,6 +36,29 @@
   max-width: 480px;
   margin: auto;
 
+  .retry-devices {
+    padding: 10px 50px;
+    background-color: #00AFEF;
+    color: #fff;
+    font-size: 16px;
+    font-family: 'DINNextLTPro-Regular';
+    line-height: 20px;
+    border-radius: 50px;
+    text-align: center;
+    cursor: pointer;
+    align-items: center;
+    display: flex;
+    display: flow-root;
+    border: none;
+    margin-top: 35px;
+    max-width: 50%;
+    margin: auto;
+    justify-content: center;
+    a {
+      margin: auto;
+    }
+  }
+
   .voxeet-loading-logo-container {
     text-align: center;
     margin-bottom: 25px;


### PR DESCRIPTION
This replaces #110.

Show remote participant mute buttons if connected to a DVCS conference, but not if connected as a listener.

Always use `start/stopAudio()` instead of `mute()` for remote participant mutes.