### PR TITLE
Fix warning about deprecated babel #112

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,16 +1,15 @@
 {
   "presets":[
-    ["@babel/preset-env", {
-      useBuiltIns: 'usage',
-      corejs: '2',
-      debug: false
-    }],
+    ["@babel/preset-env"],
     "@babel/preset-react"
   ],
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "@babel/plugin-proposal-class-properties",
     ["@babel/plugin-transform-modules-commonjs"],
-    "@babel/plugin-transform-regenerator"
+    "@babel/plugin-transform-regenerator",
+    ["polyfill-corejs3", {
+      "method": "usage-global"
+    }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "IE 11"
   ],
   "dependencies": {
-    "@babel/polyfill": "^7.2.5",
     "@babel/runtime": "^7.3.4",
+    "@voxeet/react-redux-5.1.1": "5.1.1",
     "autolinker": "^3.14.2",
     "bowser": "1.9.4",
     "browserslist": "^4.5.2",
     "can-autoplay": "^3.0.0",
     "classnames": "2.2.6",
+    "core-js": "^3.11.2",
     "css-element-queries": "1.1.1",
     "express": "^4.16.4",
     "immutable": "3.8.2",
@@ -37,14 +38,14 @@
     "react-draggable": "^3.3.2",
     "react-localization": "^1.0.13",
     "react-player": "^1.11.1",
-    "@voxeet/react-redux-5.1.1": "5.1.1",
     "react-router-dom": "^4.3.1",
     "react-tooltip": "3.9.2",
     "react-virtualized-auto-sizer": "^1.0.5",
     "react-window": "^1.8.6",
     "redux": "4.0.4",
     "redux-promise": "0.6.0",
-    "redux-thunk": "2.3.0"
+    "redux-thunk": "2.3.0",
+    "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",


### PR DESCRIPTION
@Energizz could you please review this PR. It is removing the warning about `@babel/polyfill` being deprecated.

https://babeljs.io/docs/en/babel-polyfill
https://github.com/babel/babel-polyfills/blob/main/docs/migration.md