### PR TITLE
CCU-215 Changing video settings before joining the conference on UXkit can lead to constant echo

### DIFF
--- a/src/app/components/ConferencePreConfigContainer.js
+++ b/src/app/components/ConferencePreConfigContainer.js
@@ -215,6 +215,7 @@ class ConferencePreConfigContainer extends Component {
     let videoCookieExist = false;
     let outputCookieExist = false;
     let inputCookieExist = false;
+    if (this.state.userStream) this.releaseStream();
     if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
       navigator.mediaDevices
         .enumerateDevices()


### PR DESCRIPTION
All tracks in ConferencePreConfigContainer's userStream are stopped before the new one is set.