### PR TITLE
CCU-233 Fix video not udpated after load rebalance

### DIFF
--- a/src/app/reducers/ParticipantsReducer.js
+++ b/src/app/reducers/ParticipantsReducer.js
@@ -296,7 +296,7 @@ const ParticipantReducer = (state = defaultState, action) => {
         action.payload.stream &&
         action.payload.stream.getVideoTracks().length > 0
       ) {
-        participants[index].stream = action.payload.stream;
+        participants[index] = {...participants[index], stream: action.payload.stream}
       }
       return {
         ...state,
@@ -540,7 +540,7 @@ const ParticipantReducer = (state = defaultState, action) => {
         action.payload.stream &&
         action.payload.stream.getVideoTracks().length > 0
       ) {
-        participants[index].stream = action.payload.stream;
+        participants[index] = {...participants[index], stream: action.payload.stream}
         }
       return {
         ...state,


### PR DESCRIPTION
The issue was caused by error in participant reducer that serialises data coming from streamUpdated event. The issue was that already existing participant object was modified instead of creating a new one. There is a method in electron called shouldComponentUpdate() that checks for changes in participant and stream objects, because modification occurred on object it already had reference to, it had no way of comparing what changed. Because of that error, participant video tile was not updated.
Issue was fixed by returning a copy of participant object with a new stream, so react has a way of checking what changed in participant and stream objects.