### PR TITLE
CCS 4603/CCU-309

### DIFF
--- a/src/app/actions/ConferenceActions.js
+++ b/src/app/actions/ConferenceActions.js
@@ -1278,8 +1278,8 @@ export class Actions {
         );
         if(user.status==="Left"){
           if(user.id === activeSpeaker?.activeSpeaker?.participant_id)
-          dispatch(ActiveSpeakerActions.disableForceActiveSpeaker())
-          if (participants.participants.length <= 1){
+          dispatch(ActiveSpeakerActions.stopActiveSpeaker())
+          if (participants.participants.filter(p => p.status !== "Left").length === 0){
             dispatch(ControlsActions.forceMode('tiles'))
           }
         }
@@ -1306,7 +1306,7 @@ export class Actions {
       if (index !== -1 || VoxeetSDK.session.participant.id === user.id){
         dispatch(ParticipantActions.onParticipantUpdated(user, stream));
         if(user.status ==="Left"){
-          if(user.participant_id === activeSpeaker?.activeSpeaker?.participant_id)
+          if(user.id === activeSpeaker?.activeSpeaker?.participant_id || activeSpeaker?.activeSpeaker === null)
             dispatch(ActiveSpeakerActions.disableForceActiveSpeaker());
           if (participants.participants.length <= 1){
             dispatch(ControlsActions.forceMode('tiles'))

--- a/src/app/actions/ConferenceActions.js
+++ b/src/app/actions/ConferenceActions.js
@@ -15,6 +15,7 @@ import { Actions as OnBoardingMessageActions } from "./OnBoardingMessageActions"
 import { Actions as OnBoardingMessageWithActionActions } from "./OnBoardingMessageWithActionActions";
 import { Actions as OnBoardingMessageWithConfirmationActions } from "./OnBoardingMessageWithConfirmationActions";
 import { Actions as TimerActions } from "./TimerActions";
+import {Actions as ActiveSpeakerActions} from "./ActiveSpeakerActions"
 import { strings } from "../languages/localizedStrings.js";
 import { getVideoDeviceName } from "../libs/getVideoDeviceName";
 import { isElectron, isIOS } from "../libs/browserDetection";
@@ -1256,7 +1257,7 @@ export class Actions {
   static checkIfUpdateStatusUser(user) {
     return (dispatch, getState) => {
       const {
-        voxeet: { participants },
+        voxeet: { participants,activeSpeaker },
       } = getState();
       const index = participants.participants.findIndex(
         (p) => p.participant_id === user.id
@@ -1275,6 +1276,14 @@ export class Actions {
             user.status
           )
         );
+        if(user.status==="Left"){
+          if(user.id === activeSpeaker?.activeSpeaker?.participant_id)
+          dispatch(ActiveSpeakerActions.disableForceActiveSpeaker())
+          if (participants.participants.length <= 1){
+            dispatch(ControlsActions.forceMode('tiles'))
+          }
+        }
+        
       }
       dispatch(
         ParticipantWaitingActions.onParticipantWaitingStatusUpdated(
@@ -1289,13 +1298,21 @@ export class Actions {
   static checkIfUpdateUser(user, stream) {
     return (dispatch, getState) => {
       const {
-        voxeet: { participants },
+        voxeet: { participants,activeSpeaker },
       } = getState();
       const index = participants.participants.findIndex(
         (p) => p.participant_id === user.id
       );
-      if (index !== -1 || VoxeetSDK.session.participant.id === user.id)
+      if (index !== -1 || VoxeetSDK.session.participant.id === user.id){
         dispatch(ParticipantActions.onParticipantUpdated(user, stream));
+        if(user.status ==="Left"){
+          if(user.participant_id === activeSpeaker?.activeSpeaker?.participant_id)
+            dispatch(ActiveSpeakerActions.disableForceActiveSpeaker());
+          if (participants.participants.length <= 1){
+            dispatch(ControlsActions.forceMode('tiles'))
+          }
+        }
+      }
     };
   }
 

--- a/src/app/actions/ConferenceActions.js
+++ b/src/app/actions/ConferenceActions.js
@@ -1508,6 +1508,9 @@ export class Actions {
           if (VoxeetSDK.session.participant.id === user.id) {
             dispatch(ControlsActions.toggleScreenShareMode(false));
           }
+          else {
+            dispatch(ControlsActions.restoreMode());
+          }
         } else {
           // VFS
           dispatch(ForwardedVideoActions.updateForwardedVideos());

--- a/src/app/actions/ControlsActions.js
+++ b/src/app/actions/ControlsActions.js
@@ -10,6 +10,7 @@ export const Types = {
   SHARE_ACTIONS_ALLOWED: "SHARE_ACTIONS_ALLOWED",
   TOGGLE_MODAL: "TOGGLE_MODAL",
   FORCE_MODE: "FORCE_MODE",
+  RESTORE_MODE: "RESTORE_MODE",
   TOGGLE_SCREEN_SHARE_MODE: "TOGGLE_SCREEN_SHARE_MODE",
   TOGGLE_FILE_PRESENTATION_MODE: "TOGGLE_FILE_PRESENTATION_MODE",
   TOGGLE_VIDEO_PRESENTATION_MODE: "TOGGLE_VIDEO_PRESENTATION_MODE",
@@ -111,6 +112,11 @@ export class Actions {
         mode: mode,
       },
     };
+  }
+  static restoreMode(){
+    return{
+      type:Types.RESTORE_MODE
+    }
   }
 
   static toggleScreenShareMode(isScreenshare) {

--- a/src/app/components/ConferencePreConfigContainer.js
+++ b/src/app/components/ConferencePreConfigContainer.js
@@ -174,7 +174,12 @@ class ConferencePreConfigContainer extends Component {
     VoxeetSDK.video.local.removeListener("videoStarted", this.onVideoStarted);
     VoxeetSDK.video.local.removeListener("videoUpdated", this.onVideoUpdated);
 
-    this.releaseAudioStream(true).then(() => this.releaseVideoStream(true));
+    if (this.state.userVideoStream) 
+        VoxeetSDK.video.local.stop();
+    
+    if (this.state.userAudioStream) 
+      this.state.userAudioStream.getTracks().forEach(track => track.stop());
+    
   }
 
   reportError(error) {
@@ -277,27 +282,24 @@ class ConferencePreConfigContainer extends Component {
     navigator.attachMediaStream(this.video, stream);
   }
 
-  async releaseVideoStream(onComponentUnmount=false) {
+  async releaseVideoStream() {
     if (this.state.userVideoStream) {
       await VoxeetSDK.video.local.stop();
-      if(!onComponentUnmount){
-        this.setState({
-          userVideoStream: null,
-        });
-      }
+      this.setState({
+        userVideoStream: null,
+      });
     }
   }
 
-  async releaseAudioStream(onComponentUnmount=false) {
+  async releaseAudioStream() {
     if (this.state.userAudioStream) {
       this.state.userAudioStream.getTracks().forEach((track) => {
         track.stop();
       });
-      if(!onComponentUnmount){
-        this.setState({
-          userAudioStream: null,
-        });
-      }
+
+      this.setState({
+        userAudioStream: null,
+      });
     }
   }
 

--- a/src/app/components/ConferencePreConfigContainer.js
+++ b/src/app/components/ConferencePreConfigContainer.js
@@ -174,7 +174,7 @@ class ConferencePreConfigContainer extends Component {
     VoxeetSDK.video.local.removeListener("videoStarted", this.onVideoStarted);
     VoxeetSDK.video.local.removeListener("videoUpdated", this.onVideoUpdated);
 
-    this.releaseAudioStream().then(() => this.releaseVideoStream());
+    this.releaseAudioStream(true).then(() => this.releaseVideoStream(true));
   }
 
   reportError(error) {
@@ -277,25 +277,27 @@ class ConferencePreConfigContainer extends Component {
     navigator.attachMediaStream(this.video, stream);
   }
 
-  async releaseVideoStream() {
+  async releaseVideoStream(onComponentUnmount=false) {
     if (this.state.userVideoStream) {
       await VoxeetSDK.video.local.stop();
-
-      this.setState({
-        userVideoStream: null,
-      });
+      if(!onComponentUnmount){
+        this.setState({
+          userVideoStream: null,
+        });
+      }
     }
   }
 
-  async releaseAudioStream() {
+  async releaseAudioStream(onComponentUnmount=false) {
     if (this.state.userAudioStream) {
       this.state.userAudioStream.getTracks().forEach((track) => {
         track.stop();
       });
-
-      this.setState({
-        userAudioStream: null,
-      });
+      if(!onComponentUnmount){
+        this.setState({
+          userAudioStream: null,
+        });
+      }
     }
   }
 

--- a/src/app/components/attendees/AttendeesSettings.js
+++ b/src/app/components/attendees/AttendeesSettings.js
@@ -212,11 +212,12 @@ class AttendeesSettings extends Component {
       this.setState({ videoDenoise: this.props.controlsStore.videoDenoise });
     }
 
-    if (
+    if (this.props.controlStore && this.props.controlStore.displayAttendeesList && (
       this.props.controlsStore.videoEnabled !==
         prevProps.controlsStore.videoEnabled ||
       this.props.controlsStore.audioEnabled !==
         prevProps.controlsStore.audioEnabled
+    )
     ) {
       this.initDevices();
     }

--- a/src/app/components/attendees/modes/ActiveSpeakerOverlay.js
+++ b/src/app/components/attendees/modes/ActiveSpeakerOverlay.js
@@ -35,6 +35,7 @@ class ActiveSpeakerOverlay extends Component {
 
   componentWillUnmount() {
     this.props.dispatch(ActiveSpeakerActions.stopActiveSpeaker());
+    clearTimeout(this.hideTimer)
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/app/components/attendees/modes/SpeakerActive.js
+++ b/src/app/components/attendees/modes/SpeakerActive.js
@@ -118,7 +118,7 @@ class SpeakerActive extends Component {
                       )}
                       <AttendeesParticipantVideo
                         streamId={st.stream.id}
-                        muted={isLocalScreenShare || isUserStream}
+                        muted={isLocalScreenShare}
                         stream={st.stream}
                         enableDbClick={!isLocalScreenShare}
                       />
@@ -138,7 +138,7 @@ class SpeakerActive extends Component {
                     className={mySelf ? "stream-media myself" : "stream-media"}
                   >
                     <AttendeesParticipantVideo
-                      muted={false}
+                      muted={true}
                       stream={participant.stream}
                       enableDbClick={false}
                     />

--- a/src/app/components/attendees/modes/SpeakerActive.js
+++ b/src/app/components/attendees/modes/SpeakerActive.js
@@ -118,7 +118,7 @@ class SpeakerActive extends Component {
                       )}
                       <AttendeesParticipantVideo
                         streamId={st.stream.id}
-                        muted={isLocalScreenShare}
+                        muted={isLocalScreenShare || isUserStream}
                         stream={st.stream}
                         enableDbClick={!isLocalScreenShare}
                       />

--- a/src/app/reducers/ControlsReducer.js
+++ b/src/app/reducers/ControlsReducer.js
@@ -23,6 +23,7 @@ const defaultState = {
   isKickOnHangUpActived: false,
   recordingLocked: false,
   simulcast: false,
+  modeSaved:[],
   modalOpened: true,
   displayActions: [
     "mute",
@@ -84,9 +85,21 @@ const ControlsReducer = (state = defaultState, action) => {
     case Types.FORCE_MODE:
       return {
         ...state,
-        modeSaved: state.mode,
+        modeSaved: [...state.modeSaved,state.mode],
         mode: action.payload.mode,
       };
+    case Types.RESTORE_MODE:
+      if(!state.modeSaved.length)
+        return{
+          ...state
+        }
+      let tmp = state.modeSaved.pop();
+      return{
+        ...state,
+        modeSaved: state.modeSaved,
+        mode:tmp
+      }
+
     case Types.SET_CHROME_EXTENSION_ID:
       return {
         ...state,
@@ -106,19 +119,22 @@ const ControlsReducer = (state = defaultState, action) => {
       return {
         ...state,
         isScreenshare: action.payload.isScreenshare,
-        mode: action.payload.isScreenshare ? state.mode : state.modeSaved,
+        mode: action.payload.isScreenshare ? state.mode : state.modeSaved.pop(),
+        modeSaved:state.modeSaved
       };
     case Types.TOGGLE_VIDEO_PRESENTATION_MODE:
       return {
         ...state,
         isVideoPresentation: action.payload.isVideoPresentation,
-        mode: action.payload.isVideoPresentation ? state.mode : state.modeSaved,
+        mode: action.payload.isVideoPresentation ? state.mode : state.modeSaved.pop(),
+        modeSaved:state.modeSaved
       };
     case Types.TOGGLE_FILE_PRESENTATION_MODE:
       return {
         ...state,
         isFilePresentation: action.payload.isFilePresentation,
-        mode: action.payload.isFilePresentation ? state.mode : state.modeSaved,
+        mode: action.payload.isFilePresentation ? state.mode : state.modeSaved.pop(),
+        modeSaved:state.modeSaved
       };
     case Types.TOGGLE_FULLSCREEN:
       const fullScreenStatus = !state.isWidgetFullScreenOn;

--- a/src/app/reducers/ParticipantsReducer.js
+++ b/src/app/reducers/ParticipantsReducer.js
@@ -274,7 +274,8 @@ const ParticipantReducer = (state = defaultState, action) => {
       participants[index].stream = null;
       if (
         action.payload.stream &&
-        action.payload.stream.getVideoTracks().length > 0
+        action.payload.stream.getVideoTracks().length > 0 &&
+        action.payload.status !== STATUS_LEFT
       ) {
         participants[index] = {
           ...participants[index],


### PR DESCRIPTION
- Fixed React throwing memory leak errors, issue [CCS-4603]. Issue was caused by async actions calling setState() after various components had already unmounted
- Also, changed the way the app handles forcing the user into speaker mode when screen-share is active, so it can properly restore the previous view once the stream has ended (CCU-309). This change also accommodates multiple screen-shares at once. 
- Set the video of the active speaker to muted, to avoid hearing 2 audio stream from the same participant
- Now when there is only one person, they will by forced out of speaker mode